### PR TITLE
Fix deprecated warning in CachingReflector.php

### DIFF
--- a/src/CachingReflector.php
+++ b/src/CachingReflector.php
@@ -153,10 +153,12 @@ class CachingReflector implements Reflector
         
         // Checking if the PHP version is 7 or higher, so we keep the compatibility
         if ( PHP_VERSION_ID >= 70000 ) {
-            // $param->getType() got introduced with PHP version 7
             $reflectionClass = ($param->getType() && !$param->getType()->isBuiltin()) ? new ReflectionClass($param->getType()->getName()) : null;
         } else {
-            // Keeping support for PHP version below 7 - $param->getClass() is deprecated in PHP 8+
+            // As $parameter->(has|get)Type() was only introduced with PHP 7.0+,
+			// we need to provide a work-around for PHP 5.6 while we officially
+			// support it.
+
             $reflectionClass = $param->getClass();
         }
 

--- a/src/CachingReflector.php
+++ b/src/CachingReflector.php
@@ -152,7 +152,7 @@ class CachingReflector implements Reflector
         }
         
         // Checking if the PHP version is 7 or higher, so we keep the compatibility
-        if ( PHP_VERSION_ID >= 70000 ) {
+        if (PHP_VERSION_ID >= 70000) {
             $reflectionClass = ($param->getType() && !$param->getType()->isBuiltin()) ? new ReflectionClass($param->getType()->getName()) : null;
         } else {
             // As $parameter->(has|get)Type() was only introduced with PHP 7.0+,

--- a/src/CachingReflector.php
+++ b/src/CachingReflector.php
@@ -151,8 +151,15 @@ class CachingReflector implements Reflector
             return $typeHint;
         }
         
-        $reflectionClass = ($param->getType() && !$param->getType()->isBuiltin()) ? new ReflectionClass($param->getType()->getName()) : null;
-        
+        // Checking if the PHP version is 7 or higher, so we keep the compatibility
+        if ( PHP_VERSION_ID >= 70000 ) {
+            // $param->getType() got introduced with PHP version 7
+            $reflectionClass = ($param->getType() && !$param->getType()->isBuiltin()) ? new ReflectionClass($param->getType()->getName()) : null;
+        } else {
+            // Keeping support for PHP version below 7 - $param->getClass() is deprecated in PHP 8+
+            $reflectionClass = $param->getClass();
+        }
+
         if ($reflectionClass !== null) {
             $typeHint      = $reflectionClass->getName();
             $classCacheKey = self::CACHE_KEY_CLASSES . strtolower($typeHint);

--- a/src/CachingReflector.php
+++ b/src/CachingReflector.php
@@ -156,8 +156,8 @@ class CachingReflector implements Reflector
             $reflectionClass = ($param->getType() && !$param->getType()->isBuiltin()) ? new ReflectionClass($param->getType()->getName()) : null;
         } else {
             // As $parameter->(has|get)Type() was only introduced with PHP 7.0+,
-			// we need to provide a work-around for PHP 5.6 while we officially
-			// support it.
+            // we need to provide a work-around for PHP 5.6 while we officially
+            // support it.
 
             $reflectionClass = $param->getClass();
         }

--- a/src/CachingReflector.php
+++ b/src/CachingReflector.php
@@ -150,8 +150,10 @@ class CachingReflector implements Reflector
         if (false !== $typeHint) {
             return $typeHint;
         }
-
-        if ($reflectionClass = $param->getClass()) {
+        
+        $reflectionClass = ($param->getType() && !$param->getType()->isBuiltin()) ? new ReflectionClass($param->getType()->getName()) : null;
+        
+        if ($reflectionClass !== null) {
             $typeHint      = $reflectionClass->getName();
             $classCacheKey = self::CACHE_KEY_CLASSES . strtolower($typeHint);
             $this->cache->store($classCacheKey, $reflectionClass);


### PR DESCRIPTION
This change will fix a deprecated warning showing up in PHP Version >= 8.0